### PR TITLE
require "configure xe" in service

### DIFF
--- a/modules/oracle/manifests/init.pp
+++ b/modules/oracle/manifests/init.pp
@@ -136,6 +136,6 @@ class oracle::xe {
   service {
   	"oracle-xe":
   	  ensure => "running",
-  	  require => Package["oracle-xe"],
+  	  require => [Package["oracle-xe"], Exec["configure xe"]],
   }
 }


### PR DESCRIPTION
when subscribing or requiring Service['oracle-xe'] from another module, the ordering is altered in such a way that Exec["configure xe"] can actually happen last. This ensures configuration happens always before the service.
