### PR TITLE
add rlwrap for sane readline behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ installed on the host machine you can do
 
     sqlplus system/manager@//localhost:1521/XE
 
+To make sqlplus behave like other tools (history, arrow keys etc.) you can do
+this:
+
+    rlwrap sqlplus system/manager@//localhost:1521/XE
+
 You might need to add an entry to your `tnsnames.ora` file first:
 
     XE =

--- a/modules/oracle/manifests/init.pp
+++ b/modules/oracle/manifests/init.pp
@@ -6,7 +6,7 @@ class oracle::server {
   }
 
   package {
-    ["alien", "bc", "libaio1", "unixodbc", "unzip"]:
+    ["alien", "bc", "libaio1", "unixodbc", "unzip", "rlwrap"]:
       ensure => installed;
   }
 


### PR DESCRIPTION
This installs rlwrap (http://utopia.knoware.nl/~hlub/rlwrap/#rlwrap) on the machine, so you get history and all the other good readline stuff in sqlplus.
