### PR TITLE
Add flyway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 .project
 .vagrant
 
+flyway.properties
+
 modules/oracle/files/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+modules/java
+modules/maven
+modules/stdlib
+modules/wget
+
+oracle-jdbc/ojdbc6.jar
+
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.project
 .vagrant
 
 modules/oracle/files/oracle-xe-11.2.0-1.0.x86_64.rpm.zip

--- a/README.md
+++ b/README.md
@@ -33,11 +33,20 @@ contributions.
 
         vagrant plugin install vagrant-vbguest
 
+* Install Puppet modules for Java and [Maven](http://maven.apache.org):
+
+        puppet module install puppetlabs-java --modulepath=modules
+
+		puppet module install maestrodev-maven --modulepath=modules
+		
 * Download [Oracle Database 11g Express Edition] for Linux x64. Place the file
   `oracle-xe-11.2.0-1.0.x86_64.rpm.zip` in the directory `modules/oracle/files` of this
   project. (Alternatively, you could keep the zip file in some other location and make a hard link
   to it from `modules/oracle/files`.)
 
+* Download [Oracle Database 11g Release 2 11.2.0.4 JDBC Drivers](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html) for **JDK 1.6**. 
+  Place the file `ojdbc6.jar` in the directory `oracle-jdbc` of this project.
+  
 * Run `vagrant up` from the base directory of this project. This should take a few minutes. Please
   note that building the VM involves downloading an Ubuntu 12.04
   [base box](http://docs.vagrantup.com/v2/boxes.html) which is 323MB in size.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,9 @@ Vagrant.configure("2") do |config|
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.hostname = "oracle"
 
+  # share this project under /home/vagrant/vagrant-ubuntu-oracle-xe
+  config.vm.synced_folder ".", "/home/vagrant/vagrant-ubuntu-oracle-xe", :mount_options => ["dmode=777","fmode=666"]
+  
   # Forward Oracle port
   config.vm.network :forwarded_port, guest: 1521, host: 1521
 
@@ -35,4 +38,7 @@ Vagrant.configure("2") do |config|
     puppet.manifest_file = "base.pp"
     puppet.options = "--verbose --trace"
   end
+  
+  # this runs the maven goals for data-with-flyway
+  config.vm.provision "shell", path: "flyway.sh"
 end

--- a/data-with-flyway/README.md
+++ b/data-with-flyway/README.md
@@ -1,0 +1,28 @@
+## data-with-flyway
+
+This sub-project for https://github.com/hilverd/vagrant-ubuntu-oracle-xe that contains a means for creating tables and 
+inserting data into the Oracle Express instance the parent project provides.
+
+Given you've followed all of the instructions on the parent project's README, this project is executed automatically
+by Puppet during provisioning. 
+
+If you want to add more tables and/or data to the Oracle Express instance, create additional files in src/main/resources/database/migrations
+following the examples provided.
+Learn more about adding migrations [here](http://flywaydb.org/documentation/migration/) and [here](http://flywaydb.org/documentation/migration/sql.html).
+
+### Running Flyway manually
+
+While the guest provided by the parent project is running, you can run Flyway commands manually.
+You will need to perform the steps documented in [the README for oracle-jdbc](../oracle-jdbc/README.md) to install the Oracle JDBC
+driver in your Maven repository on the host OS.
+
+Once done, running additional migrations is as simple as:
+
+> mvn install flyway:migrate
+
+If you want to drop the schema and start over from scratch:
+
+> mvn flyway:clean
+
+More commands are documented at [http://flywaydb.org/documentation/maven/](http://flywaydb.org/documentation/maven/).
+

--- a/data-with-flyway/README.md
+++ b/data-with-flyway/README.md
@@ -6,8 +6,10 @@ inserting data into the Oracle Express instance the parent project provides.
 Given you've followed all of the instructions on the parent project's README, this project is executed automatically
 by Puppet during provisioning. 
 
-If you want to add more tables and/or data to the Oracle Express instance, create additional files in src/main/resources/database/migrations
-following the examples provided.
+If you want to add more tables and/or data to the Oracle Express instance, create files in src/main/resources/database/migrations
+following the examples provided. The included examples are originally from the [Flyway Getting Started documentation](http://flywaydb.org/getstarted/firststeps/maven.html), with
+some Oracle specific changes.
+
 Learn more about adding migrations [here](http://flywaydb.org/documentation/migration/) and [here](http://flywaydb.org/documentation/migration/sql.html).
 
 ### Running Flyway manually

--- a/data-with-flyway/flyway-SAMPLE.properties
+++ b/data-with-flyway/flyway-SAMPLE.properties
@@ -1,0 +1,19 @@
+# pom.xml contains these very same options and values
+# If you want to change any flyway options and run flyway manually,
+# copy this file as 'flyway.properties' (which is gitignored) and the values 
+# in flyway.properties will take precedence.
+
+# Set the fully-qualified name of the JDBC driver class
+flyway.driver=oracle.jdbc.driver.OracleDriver
+
+# Set the JDBC URL to connect to
+flyway.url=jdbc:oracle:thin:@localhost:1521:xe
+
+# Set the credentials used to connect
+flyway.username=system
+flyway.password=manager
+
+# Set the names all schemas referenced in the migrations (schema names are CASE-SENSITIVE with Oracle)
+flyway.schemas=MYSCHEMA
+
+## Additional properties are available, see http://flywaydb.org/documentation/maven/migrate.html

--- a/data-with-flyway/pom.xml
+++ b/data-with-flyway/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.hilverd</groupId>
+	<artifactId>data-with-flyway</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>Data with Flyway</name>
+	<description>A subproject for https://github.com/hilverd/vagrant-ubuntu-oracle-xe that provides a means for creating tables and inserting data into the Oracle Express instance it provides.</description>
+
+	<properties>
+		<!-- Default properties are used in the event 'flyway.properties' is not available -->
+		<flyway.driver>oracle.jdbc.driver.OracleDriver</flyway.driver>
+		<flyway.url>jdbc:oracle:thin:@localhost:1521:xe</flyway.url>
+		<flyway.user>system</flyway.user>
+		<flyway.password>manager</flyway.password>
+		<flyway.schemas>MYSCHEMA</flyway.schemas>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.flywaydb</groupId>
+				<artifactId>flyway-maven-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<locations>
+						<location>classpath:database/migrations</location>
+					</locations>
+				</configuration>
+				<dependencies>
+					<!-- This dependency is not in Maven Central. See ../oracle-jdbc/README.md for instructions -->
+					<dependency>
+						<groupId>com.oracle</groupId>
+						<artifactId>ojdbc6</artifactId>
+						<version>11.2.0.4</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/data-with-flyway/src/main/resources/database/migrations/V1__Create_person_table.sql
+++ b/data-with-flyway/src/main/resources/database/migrations/V1__Create_person_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE MYSCHEMA.PERSON (
+    ID NUMBER(10) not null,
+    NAME VARCHAR2(100) not null
+);
+
+--ALTER TABLE PERSON ADD (
+--  CONSTRAINT person_pk PRIMARY KEY (ID));
+--
+--CREATE SEQUENCE person_seq;
+--
+--CREATE OR REPLACE TRIGGER person_autoinc 
+--BEFORE INSERT ON PERSON 
+--FOR EACH ROW
+--
+--BEGIN
+--  SELECT person_seq.NEXTVAL
+--  INTO   :new.id
+--  FROM   dual;
+--END;

--- a/data-with-flyway/src/main/resources/database/migrations/V1__Create_person_table.sql
+++ b/data-with-flyway/src/main/resources/database/migrations/V1__Create_person_table.sql
@@ -3,17 +3,17 @@ CREATE TABLE MYSCHEMA.PERSON (
     NAME VARCHAR2(100) not null
 );
 
---ALTER TABLE PERSON ADD (
---  CONSTRAINT person_pk PRIMARY KEY (ID));
---
---CREATE SEQUENCE person_seq;
---
---CREATE OR REPLACE TRIGGER person_autoinc 
---BEFORE INSERT ON PERSON 
---FOR EACH ROW
---
---BEGIN
---  SELECT person_seq.NEXTVAL
---  INTO   :new.id
---  FROM   dual;
---END;
+ALTER TABLE PERSON ADD (
+  CONSTRAINT person_pk PRIMARY KEY (ID));
+
+CREATE SEQUENCE person_seq;
+
+CREATE OR REPLACE TRIGGER person_autoinc 
+BEFORE INSERT ON PERSON 
+FOR EACH ROW
+
+BEGIN
+  SELECT person_seq.NEXTVAL
+  INTO   :new.id
+  FROM   dual;
+END;

--- a/data-with-flyway/src/main/resources/database/migrations/V2__Add_people.sql
+++ b/data-with-flyway/src/main/resources/database/migrations/V2__Add_people.sql
@@ -1,3 +1,3 @@
-insert into MYSCHEMA.PERSON (ID, NAME) values (1, 'Axel');
-insert into MYSCHEMA.PERSON (ID, NAME) values (2, 'Mr. Foo');
-insert into MYSCHEMA.PERSON (ID, NAME) values (3, 'Ms. Bar');
+insert into MYSCHEMA.PERSON (NAME) values ('Axel');
+insert into MYSCHEMA.PERSON (NAME) values ('Mr. Foo');
+insert into MYSCHEMA.PERSON (NAME) values ('Ms. Bar');

--- a/data-with-flyway/src/main/resources/database/migrations/V2__Add_people.sql
+++ b/data-with-flyway/src/main/resources/database/migrations/V2__Add_people.sql
@@ -1,0 +1,3 @@
+insert into MYSCHEMA.PERSON (ID, NAME) values (1, 'Axel');
+insert into MYSCHEMA.PERSON (ID, NAME) values (2, 'Mr. Foo');
+insert into MYSCHEMA.PERSON (ID, NAME) values (3, 'Ms. Bar');

--- a/data-with-flyway/src/main/resources/database/migrations/V3__Ms_Bar_name_change.sql
+++ b/data-with-flyway/src/main/resources/database/migrations/V3__Ms_Bar_name_change.sql
@@ -1,0 +1,1 @@
+update MYSCHEMA.PERSON set name='Mrs. Foo' where id=3;

--- a/flyway.sh
+++ b/flyway.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# this installs the oracle-jdbc driver in the local Maven repository
+cd /home/vagrant/vagrant-ubuntu-oracle-xe/oracle-jdbc; mvn install:install-file -Dfile=ojdbc6.jar -DpomFile=pom.xml
+# this runs flyway migrations
+mvn -f /home/vagrant/vagrant-ubuntu-oracle-xe/data-with-flyway/pom.xml compile flyway:migrate

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -9,3 +9,14 @@ node oracle {
     require => Service["oracle-xe"],
   }
 }
+
+# java/maven needed for flyway command
+class { 'java':
+  distribution => 'jdk',
+}
+class { "maven::maven":
+	version => "3.2.2",
+}
+package { 'maven':
+	ensure => present,
+}

--- a/oracle-jdbc/README.md
+++ b/oracle-jdbc/README.md
@@ -1,0 +1,18 @@
+## Oracle JDBC Driver
+
+This folder is here to provide people that use this project a way to install Oracle JDBC driver in their
+local Maven repository.
+
+### Installation (Manual)
+
+You don't need to do this by hand; Puppet has instructions to run these steps automatically on the guest.
+These steps are provided for reference.
+
+1. Go to [http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html)
+2. Accept the license and download the "ojdbc6.jar" file under the *Oracle Database 11g Release 2 (11.2.0.4) JDBC Drivers* heading ("Classes for use with JDK 1.6. It contains the JDBC driver classes except classes for NLS support in Oracle Object and Collection types.").
+3. Execute the following maven command to place the jar in your local Maven repository (~/.m2/repository):
+> mvn install:install-file -Dfile=ojdbc6.jar -DpomFile=pom.xml
+
+If you are running this command on Windows, since Windows' shell is terrible, you need to quote each argument individually, like so:
+
+> mvn install:install-file '-Dfile=ojdbc6.jar' '-DpomFile=pom.xml'

--- a/oracle-jdbc/pom.xml
+++ b/oracle-jdbc/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.oracle</groupId>
+	<artifactId>ojdbc6</artifactId>
+	<version>11.2.0.4</version>
+	<name>Oracle 11G JDBC Driver</name>
+	<description>Oracle Database 11g Release 2 (11.2.0.4) JDBC Drivers</description>
+</project>


### PR DESCRIPTION
This pull request adds [Flyway](http://flywaydb.org) to the provisioning process to automate creation of tables and insertion of data.

Flyway is a Java application, so it does depend on the installation of Java and Maven. In order to connect Java with Oracle, one needs a JDBC driver, which of course Oracle does not distribute freely. That does mean the addition of one more download, which I've covered on the root README.

Some bits I'm not sure about:

1. There are steps required on the host to install the Puppet forge modules for Java and/or Maven. Is there a way we can automate that? Do we need to includes those modules in git (I've gitignored them for now)?
2. I was thinking it might be desirable to skip the Flyway provisioning steps if the customer chooses. Perhaps we can craft a way to skip those steps if oracle-jdbc/ojdbc6.jar is not present?