### PR TITLE
Changed box from "precise64" to "hashicorp/precise64"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.
 
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.hostname = "oracle"
 


### PR DESCRIPTION
Vagrant fails to download box precise64. Per vagrant documentation (https://www.vagrantup.com/intro/getting-started/boxes.html) box name should be hashicorp/precise64